### PR TITLE
[SEP/Baekjoon] BOJ 7562

### DIFF
--- a/Baekjoon/src/BOJ/silver/silver01/BOJ_7562.java
+++ b/Baekjoon/src/BOJ/silver/silver01/BOJ_7562.java
@@ -1,0 +1,16 @@
+package BOJ.silver.silver01;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_7562 {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		StringBuilder sb = new StringBuilder();
+
+	}
+
+}


### PR DESCRIPTION
# 🧩 알고리즘 문제 풀이

## 📝 문제 정보
- 플랫폼: 백준
- 문제 이름: 7562 나이트의 이동
- 문제 링크: https://www.acmicpc.net/problem/7562
- 난이도: Silver 1
- 알고리즘 유형: BFS
- 풀이 일정: 2025.09.08

## 💡 접근 방법
나이트가 갈 수 있는 방향을 왼쪽 위부터 시계방향으로 돌면서 지정한다.
시작점을 큐에 저장하고, 큐가 빌때까지 반복하며 탐색한다.
현재 지점과 목표 지점이 동일하면 여태까지 이동한 횟수를 출력한다.
동일하지 않다면 8방향 탐색을 반복한다.
다음 위치가 범위를 넘어가지 않고, 방문하지 않았으면 방문 처리하고 큐에 추가한다.

## ⏱️ 시간복잡도
**O(T*N²)** 
T: 테스트 케이스의 개수
N: 체스판의 한 변의 길이

## 🥴 배운 점 & 어려웠던 점
최근 다른 문제들을 풀다보니 탐색이 다시 어렵게 느껴졌던 것 같다.

## ✅ 자가 체크리스트
- [x] 코드가 모든 테스트 케이스를 통과하나요?
- [x] 코드에 주석을 충분히 달았나요?