### PR TITLE
[APR/PRO] 86491 최소직사각형

### DIFF
--- a/Programmers/src/PRO/Lv1/PRO_86491.java
+++ b/Programmers/src/PRO/Lv1/PRO_86491.java
@@ -1,0 +1,35 @@
+package PRO.Lv1;
+
+
+public class PRO_86491 {
+  public static void main(String[] args) {
+      Solution_86491 s = new Solution_86491();
+      // 테스트케이스를 활용해 코드를 실행코드 작성하시오.
+  }
+}
+    
+class Solution_86491 {
+    public int solution(int[][] sizes) {
+        for (int[] arr : sizes) {
+            int a = arr[0];
+            int b = arr[1];
+            if (b > a) {
+                int temp = a;
+                a = b;
+                b = temp;
+            }
+            arr[0] = a;
+            arr[1] = b;
+        }
+
+        int max1 = Integer.MIN_VALUE;
+        int max2 = Integer.MIN_VALUE;
+        for (int i = 0; i < sizes.length; i++) {
+            max1 = Math.max(max1, sizes[i][0]);
+            max2 = Math.max(max2, sizes[i][1]);
+        }
+
+        int answer = max1 * max2;
+        return answer;
+    }
+}


### PR DESCRIPTION

  # 🧩 알고리즘 문제 풀이
  ## 📝 문제 정보
  - **플랫폼:** 프로그래머스 (PRO)
  - **문제 이름:** 86491 최소직사각형
  - **문제 링크:** https://programmers.co.kr/
  - **난이도:** Lv.1
  - **알고리즘 유형:** 코딩테스트 연습 > 완전탐색
  - **제출 일자:** 2026년 04월 26일 20:03:08

  ## 💡 문제 설명
  명함 지갑을 만드는 회사에서 지갑의 크기를 정하려고 합니다. 다양한 모양과 크기의 명함들을 모두 수납할 수 있으면서, 작아서 들고 다니기 편한 지갑을 만들어야 합니다. 이러한 요건을 만족하는 지갑을 만들기 위해 디자인팀은 모든 명함의 가로 길이와 세로 길이를 조사했습니다.

아래 표는 4가지 명함의 가로 길이와 세로 길이를 나타냅니다.

| 명함 번호 | 가로 길이 | 세로 길이 |
| --- | --- | --- |
| 1 | 60 | 50 |
| 2 | 30 | 70 |
| 3 | 60 | 30 |
| 4 | 80 | 40 |


가장 긴 가로 길이와 세로 길이가 각각 80, 70이기 때문에 80(가로) x 70(세로) 크기의 지갑을 만들면 모든 명함들을 수납할 수 있습니다. 하지만 2번 명함을 가로로 눕혀 수납한다면 80(가로) x 50(세로) 크기의 지갑으로 모든 명함들을 수납할 수 있습니다. 이때의 지갑 크기는 4000(=80 x 50)입니다.

모든 명함의 가로 길이와 세로 길이를 나타내는 2차원 배열 sizes가 매개변수로 주어집니다. 모든 명함을 수납할 수 있는 가장 작은 지갑을 만들 때, 지갑의 크기를 return 하도록 solution 함수를 완성해주세요.



**제한사항**


- sizes의 길이는 1 이상 10,000 이하입니다.


- sizes의 원소는 [w, h] 형식입니다.
- w는 명함의 가로 길이를 나타냅니다.
- h는 명함의 세로 길이를 나타냅니다.
- w와 h는 1 이상 1,000 이하인 자연수입니다.





**입출력 예**

| sizes | result |
| --- | --- |
| [[60, 50], [30, 70], [60, 30], [80, 40]] | 4000 |
| [[10, 7], [12, 3], [8, 15], [14, 7], [5, 15]] | 120 |
| [[14, 4], [19, 6], [6, 16], [18, 7], [7, 11]] | 133 |




**입출력 예 설명**

입출력 예 #1

문제 예시와 같습니다.

입출력 예 #2

명함들을 적절히 회전시켜 겹쳤을 때, 3번째 명함(가로: 8, 세로: 15)이 다른 모든 명함보다 크기가 큽니다. 따라서 지갑의 크기는 3번째 명함의 크기와 같으며, 120(=8 x 15)을 return 합니다.

입출력 예 #3

명함들을 적절히 회전시켜 겹쳤을 때, 모든 명함을 포함하는 가장 작은 지갑의 크기는 133(=19 x 7)입니다.

## ⏱️ 성능 요약
### 메모리
80.6 MB
### 시간
2.19 ms

## 🤔 접근 방법
작성된 내용이 없습니다.

## 🤯 어려웠던 점
작성된 내용이 없습니다.

## 📚 배운 점
작성된 내용이 없습니다.

## ✅ 자가 체크리스트

- [ ] 코드가 모든 테스트 케이스를 통과하나요?
- [ ] 코드에 주석을 충분히 달았나요?


> 출처: 프로그래머스 코딩 테스트 연습, https://school.programmers.co.kr/learn/challenges
  