### PR TITLE
[APR/PRO] 1844 게임 맵 최단거리

### DIFF
--- a/Programmers/src/PRO/Lv2/PRO_1844.java
+++ b/Programmers/src/PRO/Lv2/PRO_1844.java
@@ -1,0 +1,55 @@
+package PRO.Lv2;
+import java.util.*;
+
+public class PRO_1844 {
+  public static void main(String[] args) {
+      Solution_1844 s = new Solution_1844();
+      // 테스트케이스를 활용해 코드를 실행코드 작성하시오.
+  }
+}
+    
+class Solution_1844 {
+    // 상하좌우
+    int[] dr = {-1, 1, 0, 0};  // 행
+    int[] dc = {0, 0, -1, 1};  // 열
+    boolean[][] visited;
+    int min = Integer.MAX_VALUE;
+    
+    public int solution(int[][] maps) {
+        int n = maps.length;
+        int m = maps[0].length;
+        
+        visited = new boolean[n][m];
+        
+        int answer = bfs(n, m, maps);
+        if (answer == Integer.MAX_VALUE) answer = -1; 
+        return answer;
+    }
+    
+    public int bfs(int n, int m, int[][] maps){
+        Queue<int[]> q = new LinkedList<>();
+        q.add(new int[]{0, 0, 1});  // 캐릭터 시작위치, 이동횟수
+        visited[0][0] = true;
+        
+        while (!q.isEmpty()) {
+            int[] cur = q.poll();
+            int curR = cur[0];
+            int curC = cur[1];
+            int dist = cur[2];
+            
+            if (curR == n-1 && curC == m-1) {
+                min = Math.min(min, dist);
+            }
+            
+            for (int d = 0; d < 4; d++) {
+                int nR = curR + dr[d];
+                int nC = curC + dc[d];
+                if (nR < n && nR >= 0 && nC < m && nC >= 0 && maps[nR][nC] == 1 && !visited[nR][nC]) {
+                    q.add(new int[]{nR, nC, dist + 1});
+                    visited[nR][nC] = true;
+                }
+            }
+        }
+        return min;
+    }
+}


### PR DESCRIPTION

  # 🧩 알고리즘 문제 풀이
  ## 📝 문제 정보
  - **플랫폼:** 프로그래머스 (PRO)
  - **문제 이름:** 1844 게임 맵 최단거리
  - **문제 링크:** https://programmers.co.kr/
  - **난이도:** Lv.2
  - **알고리즘 유형:** 코딩테스트 연습 > 깊이／너비 우선 탐색（DFS／BFS）
  - **제출 일자:** 2026년 04월 28일 23:03:14

  ## 💡 문제 설명
  ROR 게임은 두 팀으로 나누어서 진행하며, 상대 팀 진영을 먼저 파괴하면 이기는 게임입니다. 따라서, 각 팀은 상대 팀 진영에 최대한 빨리 도착하는 것이 유리합니다. 

지금부터 당신은 한 팀의 팀원이 되어 게임을 진행하려고 합니다. 다음은 5 x 5 크기의 맵에, 당신의 캐릭터가 (행: 1, 열: 1) 위치에 있고, 상대 팀 진영은 (행: 5, 열: 5) 위치에 있는 경우의 예시입니다.



위 그림에서 검은색 부분은 벽으로 막혀있어 갈 수 없는 길이며, 흰색 부분은 갈 수 있는 길입니다. 캐릭터가 움직일 때는 동, 서, 남, 북 방향으로 한 칸씩 이동하며, 게임 맵을 벗어난 길은 갈 수 없습니다.

아래 예시는 캐릭터가 상대 팀 진영으로 가는 두 가지 방법을 나타내고 있습니다.


- 첫 번째 방법은 11개의 칸을 지나서 상대 팀 진영에 도착했습니다.





- 두 번째 방법은 15개의 칸을 지나서 상대팀 진영에 도착했습니다.




위 예시에서는 첫 번째 방법보다 더 빠르게 상대팀 진영에 도착하는 방법은 없으므로, 이 방법이 상대 팀 진영으로 가는 가장 빠른 방법입니다.

만약, 상대 팀이 자신의 팀 진영 주위에 벽을 세워두었다면 상대 팀 진영에 도착하지 못할 수도 있습니다. 예를 들어, 다음과 같은 경우에 당신의 캐릭터는 상대 팀 진영에 도착할 수 없습니다.



게임 맵의 상태 maps가 매개변수로 주어질 때, 캐릭터가 상대 팀 진영에 도착하기 위해서 지나가야 하는 칸의 개수의 최솟값을 return 하도록 solution 함수를 완성해주세요. 단, 상대 팀 진영에 도착할 수 없을 때는 -1을 return 해주세요.

**제한사항**


- maps는 n x m 크기의 게임 맵의 상태가 들어있는 2차원 배열로, n과 m은 각각 1 이상 100 이하의 자연수입니다.


- n과 m은 서로 같을 수도, 다를 수도 있지만, n과 m이 모두 1인 경우는 입력으로 주어지지 않습니다.

- maps는 0과 1로만 이루어져 있으며, 0은 벽이 있는 자리, 1은 벽이 없는 자리를 나타냅니다.
- 처음에 캐릭터는 게임 맵의 좌측 상단인 (1, 1) 위치에 있으며, 상대방 진영은 게임 맵의 우측 하단인 (n, m) 위치에 있습니다.




**입출력 예**

| maps | answer |
| --- | --- |
| [[1,0,1,1,1],[1,0,1,0,1],[1,0,1,1,1],[1,1,1,0,1],[0,0,0,0,1]] | 11 |
| [[1,0,1,1,1],[1,0,1,0,1],[1,0,1,1,1],[1,1,1,0,0],[0,0,0,0,1]] | -1 |


**입출력 예 설명**

입출력 예 #1

주어진 데이터는 다음과 같습니다.



캐릭터가 적 팀의 진영까지 이동하는 가장 빠른 길은 다음 그림과 같습니다.



따라서 총 11칸을 캐릭터가 지나갔으므로 11을 return 하면 됩니다.

입출력 예 #2

문제의 예시와 같으며, 상대 팀 진영에 도달할 방법이 없습니다. 따라서 -1을 return 합니다.

## ⏱️ 성능 요약
### 메모리
56.4 MB
### 시간
12.33 ms

## 🤔 접근 방법
작성된 내용이 없습니다.

## 🤯 어려웠던 점
작성된 내용이 없습니다.

## 📚 배운 점
작성된 내용이 없습니다.

## ✅ 자가 체크리스트

- [ ] 코드가 모든 테스트 케이스를 통과하나요?
- [ ] 코드에 주석을 충분히 달았나요?


> 출처: 프로그래머스 코딩 테스트 연습, https://school.programmers.co.kr/learn/challenges
  