### PR TITLE
[JUL/PRO] 43162 네트워크

### DIFF
--- a/Programmers/src/PRO/Lv3/PRO_43162.java
+++ b/Programmers/src/PRO/Lv3/PRO_43162.java
@@ -1,0 +1,43 @@
+package PRO.Lv3;
+import java.util.*;
+
+public class PRO_43162 {
+  public static void main(String[] args) {
+      Solution_43162 s = new Solution_43162();
+      // 테스트케이스를 활용해 코드를 실행코드 작성하시오.
+  }
+}
+    
+class Solution_43162 {
+    public int solution(int n, int[][] computers) {
+        boolean[] visited = new boolean[n];
+        int answer = 0;
+
+        for (int i = 0; i < n; i++) {
+            if (!visited[i]) {
+                bfs(i, computers, visited);
+                answer++;
+            }
+        }
+
+        return answer;
+    }
+
+    private void bfs(int start, int[][] computers, boolean[] visited) {
+        Queue<Integer> queue = new ArrayDeque<>();
+
+        queue.add(start);
+        visited[start] = true;
+
+        while (!queue.isEmpty()) {
+            int current = queue.poll();
+
+            for (int next = 0; next < computers.length; next++) {
+                if (computers[current][next] == 1 && !visited[next]) {
+                    visited[next] = true;
+                    queue.add(next);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION

  # 🧩 알고리즘 문제 풀이
  ## 📝 문제 정보
  - **플랫폼:** 프로그래머스 (PRO)
  - **문제 이름:** 43162 네트워크
  - **문제 링크:** https://programmers.co.kr/
  - **난이도:** Lv.3
  - **알고리즘 유형:** 코딩테스트 연습 > 깊이／너비 우선 탐색（DFS／BFS）
  - **제출 일자:** 2026년 07월 25일 19:24:29

## ⏱️ 성능 요약
| **메모리** | **시간** |
| --- | --- |
| 81.1 MB | 0.24 ms |

## 🤔 접근 방법
0번 컴퓨터부터 순서대로 확인하면서 방문하지 않은 컴퓨터가 나오면 네트워크 개수를 1 증가시키고 BFS를 수행했다. BFS에서는 시작 컴퓨터를 큐에 넣고, 현재 컴퓨터와 연결되어 있으면서 아직 방문하지 않은 컴퓨터를 계속 큐에 추가했다.  
  
BFS 한 번이 끝나면 하나의 네트워크에 속한 모든 컴퓨터가 방문 처리된다. 따라서 BFS를 새로 시작한 횟수가 전체 네트워크의 개수가 된다.

## 🤯 어려웠던 점
작성된 내용이 없습니다.

## 📚 배운 점
작성된 내용이 없습니다.

## ✅ 자가 체크리스트

- [ ] 코드가 모든 테스트 케이스를 통과하나요?
- [ ] 코드에 주석을 충분히 달았나요?


> 출처: 프로그래머스 코딩 테스트 연습, https://school.programmers.co.kr/learn/challenges
  